### PR TITLE
Added `break` statements for `PUT` and `DELETE` methods

### DIFF
--- a/src/AcuityScheduling.php
+++ b/src/AcuityScheduling.php
@@ -92,8 +92,10 @@ class AcuityScheduling {
 		case 'PUT':
 			curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
 			curl_setopt($ch, CURLOPT_POSTFIELDS, $data);
+			break;
 		case 'DELETE':
 			curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
+			break;
 		default:
 			throw new Exception("Invalid request method ({$method})");
 		}


### PR DESCRIPTION
When specifying either `PUT` or `DELETE` HTTP method options, then the case statement will fall through and throw an exception. The Acuity API supports a handful of `PUT` and at least one `DELETE` so this would effectively prevent users from making those calls using this SDK.

This fixes the bug.
