### PR TITLE
Amend check on state parameter to avoid errors in strict mode

### DIFF
--- a/src/AcuitySchedulingOAuth.php
+++ b/src/AcuitySchedulingOAuth.php
@@ -30,7 +30,7 @@ class AcuitySchedulingOAuth extends AcuityScheduling {
 			'redirect_uri'  => $this->redirectUri
 		);
 
-		if ($params['state']) {
+		if (!empty($params['state'])) {
 			$query['state'] = $params['state'];
 		}
 


### PR DESCRIPTION
Noticed an error with PHP STRICT MODE on where if no state parameter is given a warning is generated - have wrapped it in empty() to avoid this.